### PR TITLE
Fix Perl version

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,7 +1,7 @@
 {
     "name"          : "Term::termios",
     "version"       : "*",
-    "perl"          : "v6.0.0",
+    "perl"          : "6.c",
     "author"        : "github:krunen",
     "authors"       : [ "Karl Rune Nilsen" ],
     "description"   : "termios routines for Rakudo Perl 6",


### PR DESCRIPTION
Currently specified Perl version is incorrect and makes it impossible to install the module:

```
$ panda install Term::termios
==> Fetching Term::termios
Please remove leading 'v' from perl version in Term::termios's meta info.
Term::termios requires Perl version 6.0.0. Cannot continue.
  in method check-perl-version at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/sources/9036849E1656E91211D00AB4530B81D29A7D6E82 line 125
  in method install at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/sources/9036849E1656E91211D00AB4530B81D29A7D6E82 line 145
  in method resolve at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/sources/9036849E1656E91211D00AB4530B81D29A7D6E82 line 233
  in sub MAIN at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/resources/76CD539C815A33F2891D2EF3D6D96B1081567AD1 line 18
  in block <unit> at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/resources/76CD539C815A33F2891D2EF3D6D96B1081567AD1 line 150

```