### PR TITLE
Use Distribution::Resource object instead of Str

### DIFF
--- a/lib/Term/termios.pm6
+++ b/lib/Term/termios.pm6
@@ -142,7 +142,7 @@ class Term::termios is repr('CStruct') {
   sub tcgetattr(int32, Term::termios) returns int32 is native {*}
   sub tcsetattr(int32, int32, Term::termios) returns int32 is native {*}
   sub cfmakeraw(Term::termios) is native {*}
-  my constant $library = %?RESOURCES<libraries/myhelper>.Str;
+  my constant $library = %?RESOURCES<libraries/myhelper>;
 
   class termios_constants is repr('CPointer') {};
   sub termios_create_constant() returns termios_constants is native($library) {*}


### PR DESCRIPTION
Using `Str` will hardcode the lib path (eg `/path/to/repo/resources/lib.so`) and this cause issues for example when packaging the installation files in a tar archive and extracting it in another system. `Distribution::Resource` object overcomes this issue.

[Similar Fix](https://github.com/raku-community-modules/Linenoise/commit/44eccfd53488cfe39ed6c192e5b290cf73c48a91#diff-c0131abd401396134d038e56572059ffe6f72a457e863e48f5adf2176b689196L15-L16)